### PR TITLE
IOP-4114: add CONNECTHUB to provider search datasets

### DIFF
--- a/language_model_gateway/gateway/tools/provider_search_tool.py
+++ b/language_model_gateway/gateway/tools/provider_search_tool.py
@@ -48,7 +48,7 @@ class ProviderSearchTool(ResilientBaseTool):
             ) {
               searchProviders(
                 searchProvidersInput: {
-                  client: [{ dataSets: NPPES }]
+                  client: [{ dataSets: [NPPES, CONNECTHUB] }]
                   search: $search
                   searchPosition: $searchPosition
                   specialty: $specialty


### PR DESCRIPTION
Changes associated with [IOP-4114](https://icanbwell.atlassian.net/browse/IOP-4114), specifically:

1. Updating `ProviderSearchTool` to include ConnectHub providers in its output

[IOP-4114]: https://icanbwell.atlassian.net/browse/IOP-4114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ