### PR TITLE
IOP-4114: Update ProviderSearchTool datasets

### DIFF
--- a/language_model_gateway/gateway/tools/provider_search_tool.py
+++ b/language_model_gateway/gateway/tools/provider_search_tool.py
@@ -103,6 +103,17 @@ class ProviderSearchTool(ResilientBaseTool):
                   }
                   endpoint {
                     name
+                    address
+                    status
+                    identifier {
+                      system
+                      value
+                    }
+                    connectionType {
+                      code
+                      display
+                      system
+                    }
                   }
                 }
               }

--- a/language_model_gateway/gateway/tools/provider_search_tool.py
+++ b/language_model_gateway/gateway/tools/provider_search_tool.py
@@ -48,7 +48,7 @@ class ProviderSearchTool(ResilientBaseTool):
             ) {
               searchProviders(
                 searchProvidersInput: {
-                  client: [{ dataSets: [NPPES, CONNECTHUB] }]
+                  client: [{ dataSets: [CONNECTHUB, NPPES] }]
                   search: $search
                   searchPosition: $searchPosition
                   specialty: $specialty


### PR DESCRIPTION
Changes associated with [IOP-4114](https://icanbwell.atlassian.net/browse/IOP-4114), specifically:

1. Updating return order of `dataSets` in `ProviderSearchTool`, specifically for `CONNECTHUB` results to be returned first
2. Adding additional fields to the query used in `ProviderSearchTool` to return more `endpoint` related information

[IOP-4114]: https://icanbwell.atlassian.net/browse/IOP-4114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ