### PR TITLE
optimize github analyzer

### DIFF
--- a/docker-compose-openwebui.yml
+++ b/docker-compose-openwebui.yml
@@ -1,7 +1,7 @@
 services:
   open-webui:
     # https://github.com/open-webui/open-webui/releases
-    image: ghcr.io/open-webui/open-webui:v0.5.4
+    image: ghcr.io/open-webui/open-webui:v0.5.7
     depends_on:
       - open-webui-db
     env_file:

--- a/language_model_gateway/gateway/tools/github_pull_request_analyzer_tool.py
+++ b/language_model_gateway/gateway/tools/github_pull_request_analyzer_tool.py
@@ -236,8 +236,10 @@ class GitHubPullRequestAnalyzerTool(ResilientBaseTool):
             # Initialize GitHub Pull Request Helper
             # Retrieve closed pull requests
             max_repos: int = int(os.environ.get("GITHUB_MAXIMUM_REPOS", 100))
-            max_pull_requests: int = int(
-                os.environ.get("GITHUB_MAXIMUM_PULL_REQUESTS_PER_REPO", 100)
+            max_pull_requests: Optional[int] = (
+                int(os.environ.get("GITHUB_MAXIMUM_PULL_REQUESTS_PER_REPO", 100))
+                if not counts_only
+                else None
             )
             if limit:
                 max_pull_requests = limit

--- a/language_model_gateway/gateway/utilities/github/github_pull_request_helper.py
+++ b/language_model_gateway/gateway/utilities/github/github_pull_request_helper.py
@@ -212,8 +212,22 @@ class GithubPullRequestHelper:
                         prs.extend(prs_response.json())
                         if len(prs_response.json()) == 0:
                             pages_remaining = False
-                        elif max_pull_requests and len(prs) >= max_pull_requests:
-                            pages_remaining = False
+                        else:
+                            if max_pull_requests and len(prs) >= max_pull_requests:
+                                pages_remaining = False
+
+                            if max_created_at:
+                                pr_created_at = datetime.fromisoformat(
+                                    prs[-1]["created_at"].replace("Z", "+00:00")
+                                )
+                                if pr_created_at <= max_created_at:
+                                    pages_remaining = False
+                            if min_created_at:
+                                pr_created_at = datetime.fromisoformat(
+                                    prs[-1]["created_at"].replace("Z", "+00:00")
+                                )
+                                if pr_created_at < min_created_at:
+                                    pages_remaining = False
                         page_number += 1
 
                     for pr_index, pr in enumerate(prs):


### PR DESCRIPTION
1. Docker Compose Update:
   - The Open WebUI image has been updated from `v0.5.4` to `v0.5.7`
   - This appears to be a minor version upgrade, which typically includes bug fixes or small improvements

2. GitHub Pull Request Analyzer Tool Changes:
   - In `github_pull_request_analyzer_tool.py`, there's a modification to how `max_pull_requests` is set:
     ```python
     max_pull_requests: Optional[int] = (
         int(os.environ.get("GITHUB_MAXIMUM_PULL_REQUESTS_PER_REPO", 100))
         if not counts_only
         else None
     )
     ```
   - This change allows `max_pull_requests` to be `None` when `counts_only` is `True`, which makes sense as you wouldn't need to limit pull request retrieval when just getting counts

3. GitHub Pull Request Helper Changes:
   - In `github_pull_request_helper.py`, the pagination logic for retrieving pull requests has been enhanced:
     ```python
     if max_pull_requests and len(prs) >= max_pull_requests:
         pages_remaining = False

     if max_created_at:
         pr_created_at = datetime.fromisoformat(
             prs[-1]["created_at"].replace("Z", "+00:00")
         )
         if pr_created_at <= max_created_at:
             pages_remaining = False
     if min_created_at:
         pr_created_at = datetime.fromisoformat(
             prs[-1]["created_at"].replace("Z", "+00:00")
         )
         if pr_created_at < min_created_at:
             pages_remaining = False
     ```
   - The new code adds additional conditions to stop pagination:
     1. When the number of pull requests reaches `max_pull_requests`
     2. When the last pull request's creation date is beyond `max_created_at`
     3. When the last pull request's creation date is before `min_created_at`

Observations and Recommendations:
1. The changes look clean and well-thought-out
2. The code improvements seem to add more robust handling of pull request retrieval
3. The version upgrade for Open WebUI is minor and likely safe
