### PR TITLE
set WEBUI_URL environment variable

### DIFF
--- a/docker-compose-openwebui-auth.yml
+++ b/docker-compose-openwebui-auth.yml
@@ -16,6 +16,7 @@ services:
       OAUTH_PROVIDER_NAME: "keycloak"
       OAUTH_SCOPES: "openid email"
       OAUTH_USERNAME_CLAIM: "email"
+      WEBUI_URL: "https://open-webui.localhost"
 
   keycloak:
     # https://github.com/keycloak/keycloak/releases


### PR DESCRIPTION
This PR adds a new environment variable, WEBUI_URL, to the docker-compose configuration for the OpenWebUI authentication setup.

Adds WEBUI_URL with a specified URL in docker-compose-openwebui-auth.yml
Updates the OpenWebUI environment settings for improved configuration