### PR TITLE
EA-0000 Update prod FHIR URL from fhir-mcp to fhir

### DIFF
--- a/docker-compose-mcp-fhir-agent.yml
+++ b/docker-compose-mcp-fhir-agent.yml
@@ -384,7 +384,7 @@ services:
     image: mcp-fhir-agent:local
     environment:
       <<: *agent_env
-      FHIR_SERVER_GET_URL: 'https://fhir-mcp.prod.bwell.zone/4_0_0/'
+      FHIR_SERVER_GET_URL: 'https://fhir.prod.bwell.zone/4_0_0/'
       TOKEN_EXCHANGE_GRAPHQL_URL: 'https://api.prod.icanbwell.com/v1/graphql'
       ATC_BFF_GRAPHQL: 'https://api-gateway.prod.icanbwell.com/atc-bff/v2/graphql'
       PSS_BASE_URL: 'https://api-gateway.prod.icanbwell.com/provider-search/graphql'


### PR DESCRIPTION
## Summary

- Replace `fhir-mcp.prod.bwell.zone` with `fhir.prod.bwell.zone` in `docker-compose-mcp-fhir-agent.yml`

## Test plan

- [ ] Verify docker-compose config uses correct FHIR endpoint